### PR TITLE
Attempt to handle another @loader_path case

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -110,6 +110,11 @@ fn get_potential_paths(
             path.push(lib);
             paths.push(path);
         }
+    } else if lib.starts_with("@executable_path/") || lib.starts_with("@loader_path/") {
+        let lib = lib.split_once('/').unwrap().1;
+        let mut path = PathBuf::from(executable_path.parent().unwrap());
+        path.push(lib);
+        paths.push(path);
     } else {
         let mut path = PathBuf::from(shared_cache_root);
         let stripped = lib.strip_prefix('/').unwrap();


### PR DESCRIPTION
Previously this case would fallthrough to the else and crash:

```
% otool -L /opt/homebrew/opt/icu4c@78/lib/libicui18n.78.dylib
/opt/homebrew/opt/icu4c@78/lib/libicui18n.78.dylib:
        /opt/homebrew/opt/icu4c@78/lib/libicui18n.78.dylib (compatibility version 78.0.0, current version 78.2.0)
        @loader_path/libicuuc.78.dylib (compatibility version 78.0.0, current version 78.2.0)
        @loader_path/libicudata.78.dylib (compatibility version 78.0.0, current version 78.2.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1356.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 2000.67.0)
```

Fixes https://github.com/keith/dylibtree/issues/2
